### PR TITLE
Fix bug in rad-addpath to prevent duplicate entries. Fix import of pr…

### DIFF
--- a/init-plugin/init-plugin.plugin.zsh
+++ b/init-plugin/init-plugin.plugin.zsh
@@ -86,13 +86,24 @@ rad-realpath() {
 # Add a directory to the path only if it's not already there
 rad-addpath() {
   local new_path=$1
-  # Check if the new path is already in $PATH
-  if [[ ! ":$PATH:" == *":$new_path:"* ]]; then
-    export PATH="$PATH:$new_path"
+
+  # Check if the new path is provided
+  if [[ -z "$new_path" ]]; then
+    echo "Usage: rad-addpath <path>"
+    return 1
   fi
-  export PATH="$PATH:$RAD_SHELL_DIR/bin"
+
+  # Check if the new path is already in $PATH
+  if [[ ":$PATH:" != *":$new_path:"* ]]; then
+    export PATH="$new_path:$PATH"
+  fi
 }
 
 # Make rad-shell bins available to path
 export RAD_SHELL_DIR="$(rad-realpath "${0:a:h}/..")"
-rad-addpath $RAD_SHELL_DIR
+rad-addpath "${RAD_SHELL_DIR}/bin"
+
+# Ensure ZSH_CACHE_DIR & ZSH_COMPLETIONS_DIR are setup
+export ZSH_CACHE_DIR="$HOME/.cache/zsh"
+export ZSH_COMPLETIONS_DIR="${ZSH_CACHE_DIR}/completions"
+mkdir -p "${ZSH_COMPLETIONS_DIR}"


### PR DESCRIPTION
…oj-zaw. Ensure ZSH_CACHE_DIR is set and completions directory is setup to fix error message from oh-my-zsh docker plugin

Fixes:
- rad-addpath was not correctly preventing duplicate entries from being added to the path
- ZSH_CACHE_DIR was not set, leading to some oh-my-zsh plugins not being able to find completions
- proj-zaw was moved from the zaw plugin to the shell-tools plugin, where `proj` itself is defined.  This change fixes the import statement so it will be correctly imported